### PR TITLE
feat: Add Syntax Highlighting and File Support for W++

### DIFF
--- a/v2/keywords.go
+++ b/v2/keywords.go
@@ -117,6 +117,9 @@ var (
 
 	// SuperCollider
 	superColliderWords = []string{"arg", "var", "nil", "true", "false", "this", "super", "thisProcess", "thisThread", "thisMethod", "thisFunction", "currentEnvironment", "topEnvironment", "inf", "pi", "__FILE__", "__LINE__"}
+	
+	// W++
+	wppWords = []string{"let", "if", "else", "while", "for", "break", "continue", "true", "false", "switch", "case", "default", "try", "catch", "throw", "finally", "funcy", "return", "async", "await", "const", "print", "http.get","http.post", "http.put", "http.patch", "http.delete", "http.status", "http.body", "http.headers", "server.register", "server.start"}
 
 	// Keywords contains the default syntax highlighting keywords
 	Keywords = map[string]struct{}{

--- a/v2/syntax.go
+++ b/v2/syntax.go
@@ -304,6 +304,8 @@ func adjustSyntaxHighlightingKeywords(m mode.Mode) {
 		delKeywords := []string{"from", "in", "ret", "static"} // static is treated separately, as a special keyword
 		addAndRemoveKeywords(addKeywords, delKeywords)
 		fallthrough // Continue to the default
+    case mode.Wpp:
+		setKeywords(wppWords)
 	default:
 		addKeywords := []string{"elif", "endif", "ifeq", "ifneq"}
 		delKeywords := []string{"build", "done", "package", "require", "set", "super", "type", "when"}
@@ -350,6 +352,8 @@ func (e *Editor) SingleLineCommentMarker() string {
 		return "["
 	case mode.Vim:
 		return "\""
+	case mode.Wpp:
+		return "//"
 	default:
 		return "//"
 	}

--- a/v2/vendor/github.com/xyproto/mode/filename.go
+++ b/v2/vendor/github.com/xyproto/mode/filename.go
@@ -269,6 +269,8 @@ func Detect(filename string) Mode {
 			mode = Text
 		case ".v":
 			mode = V
+		case ".wpp":
+			mode = Wpp
 		case ".xml":
 			mode = XML
 		case ".zig", ".zir":

--- a/v2/vendor/github.com/xyproto/mode/mode.go
+++ b/v2/vendor/github.com/xyproto/mode/mode.go
@@ -115,6 +115,7 @@ const (
 	TypeScript            // TypeScript
 	V                     // V programming language
 	Vim                   // Vim or NeoVim configuration, or .vim scripts
+	Wpp                   // W++ programming language
 	XML                   // XML
 	Zig                   // Zig
 )
@@ -344,6 +345,8 @@ func (mode Mode) String() string {
 		return "ViM"
 	case V:
 		return "V"
+	case Wpp:
+		return "W++"
 	case XML:
 		return "XML"
 	case Zig:


### PR DESCRIPTION
Hey there! 👋 It’s me — the one from the earlier W++ issue 😄

I’ve added syntax highlighting and file extension support for the W++ programming language.
Tested on macOS (via zsh) — works great! Also tested on Windows, where I saw your “not supported yet” message (made me laugh, thanks for that 😂).

Notes:

I’ve updated the local mode package to include W++ file and mode support.
If this needs to be removed for the upstream mode package to take over later, I can easily revert that.

I placed the W++ built-ins (e.g. http.get, server.start, etc.) together with the rest of the syntax group — wasn’t sure where they best fit, but it works cleanly for now.

Once again, thank you so much for allowing me to bring W++ into Orbiton — I can’t tell you how much I appreciate it. This really means a lot! 🙏

— Ofek 🦥
Developer of W++
https://github.com/sinisterMage/WPlusPlus